### PR TITLE
Added 2.3.0 as a valid Pillow version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='Apache License, Version 2.0',
 
     install_requires=[
-        'Pillow==2.2.1',
+        'Pillow==2.2.1,==2.3.0',
         'django-mptt==0.6.0',
         'django_compressor==1.3',
         'djangorestframework==2.3.8',


### PR DESCRIPTION
Exact requirements are too strict. If I have another package that requires `Pillow==2.2.2`, then one of them won't install (not without `--no-deps`, that is).