### PR TITLE
Fixed problems that occur when django is deployed at a non-root url.

### DIFF
--- a/fiber/managers.py
+++ b/fiber/managers.py
@@ -12,6 +12,8 @@ from .utils.urls import get_named_url_from_quoted_url
 from .utils.class_loader import load_class
 from .app_settings import PERMISSION_CLASS
 
+from django.core.urlresolvers import get_script_prefix
+
 
 class ContentItemManager(models.Manager):
 
@@ -222,7 +224,7 @@ class PageManager(TreeManager):
             url = page.get_absolute_url()
             if url:
                 # normal pages
-                page_info['url'] = url
+                page_info['url'] = get_script_prefix().rstrip('/') + url
                 page_info['change_url'] = page.get_change_url()
                 page_info['add_url'] = page.get_add_url()
 

--- a/fiber/middleware.py
+++ b/fiber/middleware.py
@@ -165,7 +165,7 @@ class AdminPageMiddleware(object):
         return True
 
     def is_django_admin(self, request):
-        return re.search(r'^%s' % (reverse('admin:index').lstrip('/')), request.path_info.lstrip('/'))
+        return re.search(r'^%s' % (reverse('admin:index').lstrip('/')), request.path.lstrip('/'))
 
     def get_header_html(self, request):
         t = loader.get_template('fiber/header.html')

--- a/fiber/models.py
+++ b/fiber/models.py
@@ -2,7 +2,7 @@ import os
 import json
 import warnings
 
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, get_script_prefix
 from django.core.files.images import get_image_dimensions
 from django.db import models
 from django.utils.html import strip_tags

--- a/fiber/static/fiber/js/admin.js
+++ b/fiber/static/fiber/js/admin.js
@@ -754,7 +754,7 @@ var BaseFileSelectDialog = AdminRESTDialog.extend({
 Fiber.ImageSelectDialog = BaseFileSelectDialog.extend({
 
 	defaults: {
-		url: '/api/v2/images/',
+		url: FIBER_API_ROOT + 'images/',
 		width: 520,
 		height: 'auto',
 		start_width: 480,
@@ -833,7 +833,7 @@ Fiber.ImageSelectDialog = BaseFileSelectDialog.extend({
 	},
 
 	get_upload_path: function() {
-		return '/api/v2/images/';
+		return FIBER_API_ROOT + 'images/';
 	},
 
 	get_selected_row: function() {
@@ -849,7 +849,7 @@ Fiber.ImageSelectDialog = BaseFileSelectDialog.extend({
 Fiber.FileSelectDialog = BaseFileSelectDialog.extend({
 
 	defaults: {
-		url: '/api/v2/files/',
+		url: FIBER_API_ROOT + 'files/',
 		width: 520,
 		height: 'auto',
 		start_width: 480,
@@ -913,7 +913,7 @@ Fiber.FileSelectDialog = BaseFileSelectDialog.extend({
 	},
 
 	get_upload_path: function() {
-		return '/api/v2/files/';
+		return FIBER_API_ROOT + 'files/';
 	},
 
 	action_click: function() {
@@ -933,7 +933,7 @@ Fiber.FileSelectDialog = BaseFileSelectDialog.extend({
 Fiber.PageSelectDialog = AdminRESTDialog.extend({
 
 	defaults: {
-		url: '/api/v2/pages/',
+		url: FIBER_API_ROOT + 'pages/',
 		width: 480,
 		height: 520,
 		start_width: 480,
@@ -999,7 +999,7 @@ Fiber.PageSelectDialog = AdminRESTDialog.extend({
 		}
 
 		$.ajax({
-			url: '/api/v2/pagetree/',
+			url: FIBER_API_ROOT + 'pagetree/',
 			type: 'GET',
 			success: $.proxy(handle_load_data, this),
 			cache: false,
@@ -1237,7 +1237,7 @@ var DroppableArea = Class.extend({
 		busyIndicator.show();
 
 		$.ajax({
-			url: '/api/v2/page_content_items/',
+			url: FIBER_API_ROOT + 'page_content_items/',
 			type: 'POST',
 			data: data,
 			success: function(response) {
@@ -1250,7 +1250,7 @@ var DroppableArea = Class.extend({
 		busyIndicator.show();
 
 		Fiber.move_page_content_item(
-			'/api/v2/page_content_items/' + fiber_item_data.page_content_item_id + '/move/',
+			FIBER_API_ROOT + 'page_content_items/' + fiber_item_data.page_content_item_id + '/move/',
 			this.fiber_item.element_data.page_content_item_id,
 			this.fiber_item.element_data.block_name
 		)
@@ -1311,7 +1311,7 @@ var AddContentItemFormDialog = ChangeContentItemFormDialog.extend({
 		busyIndicator.show();
 
 		$.ajax({
-			url: '/api/v2/page_content_items/',
+			url: FIBER_API_ROOT + 'page_content_items/',
 			type: 'POST',
 			data: data,
 			success: function(response) {
@@ -1411,7 +1411,7 @@ var adminPage = {
 
 			var info = event.move_info;
 			$.ajax({
-				url: '/api/v2/pages/' + info.moved_node.id + '/move_page/',
+				url: FIBER_API_ROOT + 'pages/' + info.moved_node.id + '/move_page/',
 				type: 'POST',
 				dataType: 'json',
 
@@ -1588,7 +1588,7 @@ var adminPage = {
 									busyIndicator.show();
 
 									$.ajax({
-										url: '/api/v2/pages/' + node.id + '/',
+										url: FIBER_API_ROOT + 'pages/' + node.id + '/',
 										type: 'DELETE',
 										data: {},
 										success: function(data) {
@@ -1671,7 +1671,7 @@ var adminPage = {
 								busyIndicator.show();
 
 								$.ajax({
-									url: '/api/v2/content_items/' + node.id + '/',
+									url: FIBER_API_ROOT + 'content_items/' + node.id + '/',
 									type: 'DELETE',
 									data: {},
 									success: function(data) {
@@ -1800,7 +1800,7 @@ var adminPage = {
 
 		var backend_toolbar = $('<div id="fiber-backend-toolbar"></div>');
 		var frontend_button = $('<p class="frontend"></p>').appendTo(backend_toolbar);
-		var link = $(document.createElement('a')).text(gettext('Frontend')).attr('href', '/').attr('title', gettext('Frontend')).appendTo(frontend_button);
+		var link = $(document.createElement('a')).text(gettext('Frontend')).attr('href', DEPLOY_ROOT).attr('title', gettext('Frontend')).appendTo(frontend_button);
 		$('<span class="icon"></span>').prependTo(link);
 		backend_toolbar.prependTo($('body'));
 	},
@@ -1879,10 +1879,10 @@ function reloadPage(params) {
 		busyIndicator.show();
 
 		$.ajax({
-			url: '/api/v2/pages/' + page_id + '/',
+			url: FIBER_API_ROOT + 'pages/' + page_id + '/',
 			type: 'GET',
 			success: function(data) {
-				window.location.replace(data.page_url);
+				window.location.replace((DEPLOY_ROOT + data.page_url).replace('//', '/'));
 			},
 			error: function() {
 				if (params && params.error) {
@@ -2236,7 +2236,7 @@ Fiber.FiberItem = Class.extend({
 		adminPage.hide_admin_elements();
 
 		$.ajax({
-			url: '/api/v2/page_content_items/' + this.element_data.page_content_item_id + '/',
+			url: FIBER_API_ROOT + 'page_content_items/' + this.element_data.page_content_item_id + '/',
 			type: 'DELETE',
 			data: {},
 			success: function(data) {

--- a/fiber/templates/fiber/header.html
+++ b/fiber/templates/fiber/header.html
@@ -38,6 +38,10 @@
 <script src="{{ STATIC_URL }}fiber/js/file-uploader-3.2.0/client/js/handler.form.js" type="text/javascript"></script>
 <script src="{{ STATIC_URL }}fiber/js/file-uploader-3.2.0/client/js/handler.xhr.js" type="text/javascript"></script>
 
+<script type="text/javascript">
+    var FIBER_API_ROOT = '{% url 'fiber.rest_api.views.api_root' %}';
+    var DEPLOY_ROOT = FIBER_API_ROOT.replace("api/v2/", "");
+</script>
 <script src="{{ STATIC_URL }}fiber/js/admin-extra.js" type="text/javascript"></script>
 <script src="{{ STATIC_URL }}fiber/js/admin.js" type="text/javascript"></script>
 {% endcompress %}

--- a/fiber/templates/fiber/menu.html
+++ b/fiber/templates/fiber/menu.html
@@ -1,4 +1,7 @@
 {% load mptt_tags fiber_tags %}
+
+{% url 'fiber.views.page' as fiber_root_url %}
+
 {% if user.is_staff %}
     {% if fiber_menu_parent_page %}
 
@@ -24,7 +27,7 @@
             {% if not node.is_public %}df-non-public{% endif %}
             {% if node.redirect_page %}df-redirect{% endif %}
         ">
-            <a href="{{ node.get_absolute_url }}"
+            <a href="{{ fiber_root_url|slice:":-1" }}{{ node.get_absolute_url }}"
                 data-fiber-data='{
                     {% if node|can_edit:user %}"can_edit": true,{% endif %}
                     "type": "page",
@@ -66,7 +69,7 @@
             {% if node.is_first_child %}first{% endif %}
             {% if node.is_last_child %}last{% endif %}
         ">
-            <a href="{{ node.get_absolute_url }}">{{ node.title }}</a>
+            <a href="{{ fiber_root_url|slice:":-1" }}{{ node.get_absolute_url }}">{{ node.title }}</a>
 
             {% if children %}
 


### PR DESCRIPTION
I am a new user of django-fiber.  I like it a lot, but unfortunately I has some problems when I deployed my django project at a non-root url of a server.  I made some changes to fix these problems.  As far as I tested, it seems like all the problems I found have been fixed.  I hope this can be merged into a future release.  As mentioned in the commit log, the problems fixed include:
- The right side menu pane appeared even in the admin mode.
- The navigation menu items were linked to wrong urls.
- The frontpage link at the top of the admin page were liked to a wrong url.
- Ckeditor was not activated in several admin pages.
- The page layout was broken in several admin pages.
- Numerous behaviors in ckeditor did not work (eg. adding an image)
- After in-line editing a content item, the page was not reloaded properly.
