### PR TITLE
Cleaner setup failure on python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ version = __import__('fiber').__version__
 
 if sys.argv[-1] == 'publish':  # upload to pypi
     os.system("python setup.py register sdist bdist_egg bdist_wheel upload")
-    print "You probably want to also tag the version now:"
-    print "  git tag -a %s -m 'version %s'" % (version, version)
-    print "  git push --tags"
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %s -m 'version %s'" % (version, version))
+    print("  git push --tags")
     sys.exit()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ from setuptools import setup, find_packages
 
 version = __import__('fiber').__version__
 
+if sys.version_info[0] > 2:
+    sys.exit('Python > 2 is unsupported.')
+
 if sys.argv[-1] == 'publish':  # upload to pypi
     os.system("python setup.py register sdist bdist_egg bdist_wheel upload")
     print("You probably want to also tag the version now:")


### PR DESCRIPTION
Currently, attempting to install django-fiber on python3 results in a SyntaxError. This can be difficult to debug and cause frustration for users who are new to Python:

`SyntaxError: Missing parentheses in call to 'print'`

These minor changes improve the way setup.py fails on python3, enabling the user to immediately understand what's going on.