### PR TITLE
Remove broken pypi badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 [travis-url]: http://travis-ci.org/#!/ridethepony/django-fiber
 [travis-build-image]: https://secure.travis-ci.org/ridethepony/django-fiber.png?branch=dev
 
-[pypi-url]: https://pypi.python.org/pypi/django-fiber/
-[pypi-image]: https://pypip.in/d/django-fiber/badge.png
-
 [coveralls-url]: https://coveralls.io/r/ridethepony/django-fiber
 [coveralls-image]: https://coveralls.io/repos/ridethepony/django-fiber/badge.png?branch=dev
 


### PR DESCRIPTION
The badge hosting at `pypip.in` has been broken for a while now, and
doesn't seem to be coming back anytime soon. See the following:

- badges/pypipins#37
- badges/pypipins#38
- badges/pypipins#39