### PR TITLE
Add 'downloads' badge from shields.io. Also use svg for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [travis-url]: http://travis-ci.org/#!/ridethepony/django-fiber
-[travis-build-image]: https://secure.travis-ci.org/ridethepony/django-fiber.png?branch=dev
+[travis-build-image]: https://secure.travis-ci.org/ridethepony/django-fiber.svg?branch=dev
 
 [coveralls-url]: https://coveralls.io/r/ridethepony/django-fiber
-[coveralls-image]: https://coveralls.io/repos/ridethepony/django-fiber/badge.png?branch=dev
-
+[coveralls-image]: https://coveralls.io/repos/ridethepony/django-fiber/badge.svg?branch=dev
 
 [![Travis build image][travis-build-image]][travis-url]
+[![PyPI](https://img.shields.io/pypi/dm/django-fiber.svg)]()
 [![Coverage Status][coveralls-image]][coveralls-url]
 
 # Django Fiber


### PR DESCRIPTION
Restore the **downloads** badge using shields.io. The previous badge from pypip.in was broken.
Use svg for all badges.