### PR TITLE
Fixed RemovedInDjango19Warning using Django 1.8

### DIFF
--- a/fiber/admin.py
+++ b/fiber/admin.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib import admin, messages
-from django.contrib.admin.util import model_ngettext
+from django.contrib.admin.utils import model_ngettext
 from django.utils.translation import ugettext_lazy as _
 from django.db.models.deletion import ProtectedError
 from django.core.exceptions import PermissionDenied


### PR DESCRIPTION
When using Django 1.8.11 doing 'from django.contrib.admin.util' throws a RemovedInDjango19Warning, changing that to 'from django.contrib.admin.utils' removes the warning.