### PR TITLE
Fixed fiber not posting the ID of the content_item

### DIFF
--- a/fiber/static/fiber/js/admin.js
+++ b/fiber/static/fiber/js/admin.js
@@ -1295,7 +1295,7 @@ var AddContentItemFormDialog = ChangeContentItemFormDialog.extend({
 
 		this.after_action_success = $.proxy(function(responseText, statusText, xhr, $form) {
 			// find id of added content item
-			var added_content_item_id = xhr.responseXML.URL.replace(/\/$/,'').split('/').pop();
+			var added_content_item_id = xhr.responseXML.URL.replace(/\/$/,'').split('/').slice(-2)[0];
 
 			if (added_content_item_id) {
 				this.add_content_item(added_content_item_id);


### PR DESCRIPTION
After the content_item was created, another request would POST to join the content-item to the page. This request would post "change" as content_item_id (it being the last part of the URL), changed that to actually post the id of the content_item.