### PR TITLE
Remove unused styling referencing unused images blocking collectstatic

### DIFF
--- a/fiber/static/fiber/css/widgets.css
+++ b/fiber/static/fiber/css/widgets.css
@@ -89,15 +89,3 @@
 	cursor: pointer;
 	color: #cc3434
 }
-
-.fiber-json-widget a.add-btn {
-	cursor: pointer;
-	margin-left: 5px;
-	color: #5b80b2;
-  background: url("../../admin/img/icon_addlink.gif") no-repeat scroll 0 0.25em transparent;
-  padding-left: 12px;
-}
-
-.fiber-json-widget tr.add-row {
-	background: url("../../admin/img/nav-bg.gif") repeat-x scroll left top #e1e1e1;
-}


### PR DESCRIPTION
The removed css refences files that do not exist anymore. While doing collectstatic with post-processing these missing files cause the script to abort.