### PR TITLE
Avoid deprecation warning in URLconf on Django 1.10 and above

### DIFF
--- a/fiber/admin_urls.py
+++ b/fiber/admin_urls.py
@@ -10,6 +10,6 @@ urlpatterns = [
     url(r'^page/(?P<id>\d+)/move_down/$', admin_views.page_move_down, name='fiber_page_move_down'),
     url(r'^login/$', admin_views.fiber_login, name='fiber_login'),
     url(r'^pages.json$', admin_views.pages_json, name='pages_json'),
-    url(r'^fiber_admin/', include(fiber_admin.site.urls)),
+    url(r'^fiber_admin/', fiber_admin.site.urls),
     url(r'^jsi18n/$', javascript_catalog, {'packages': ['fiber']}, name='fiber_i18n'),
 ]

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     url(r'^api/v2/', include('fiber.rest_api.urls')),
     url(r'^admin/fiber/', include('fiber.admin_urls')),
 
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
This method works from at least 1.8 onwards, though not documented as
working in Django 1.8